### PR TITLE
`FractionCompletedNotification` can fail to notify when `isComplete` becomes true

### DIFF
--- a/Sources/CSProgress/CSProgress.swift
+++ b/Sources/CSProgress/CSProgress.swift
@@ -600,7 +600,7 @@ public final class CSProgress: CustomDebugStringConvertible {
                     parent.sendFractionCompletedNotifications(fractionCompleted: parent.backing.fractionCompleted, isCompleted: parent.backing.isCompleted, completionHandler: completionHandler)
                 }
             }
-        } else if abs(fractionCompleted - lastNotifiedFractionCompleted) >= self.granularity {
+        } else if (isCompleted && lastNotifiedFractionCompleted != 1.0) || abs(fractionCompleted - lastNotifiedFractionCompleted) >= self.granularity {
             let completedUnitCount = self.backing.completedUnitCount
             let totalUnitCount = self.backing.totalUnitCount
             


### PR DESCRIPTION
In the case with updated progress where `isComplete` becomes true, the `fractionCompleted` notification can fail to fire if the progress doesn't have a parent, and the receiver will never get notified that the progress is in fact complete! This handles that case.

Yes, setting `granularity` to something more granular *could* solve the problem, but I think everyone always wants to be notified when the progress is complete, regardless of granularity.